### PR TITLE
[Typo fix] Changed Classcification to Classification in 4 lines.

### DIFF
--- a/scripts/civitai_manager_libs/civitai_action.py
+++ b/scripts/civitai_manager_libs/civitai_action.py
@@ -59,8 +59,8 @@ def on_ui(refresh_sc_list:gr.Textbox()):
 
                 with gr.Row():                        
                     with gr.Column():
-                        with gr.Accordion("Classcification", open=True):
-                            model_classification = gr.Dropdown(label='Classcification', show_label=False ,multiselect=True, interactive=True, choices=classification.get_list())
+                        with gr.Accordion("Classification", open=True):
+                            model_classification = gr.Dropdown(label='Classification', show_label=False ,multiselect=True, interactive=True, choices=classification.get_list())
                             model_classification_update_btn = gr.Button(value="Update",variant="primary")     
                                                                                     
                         with gr.Accordion("Downloaded Version", open=True, visible=False)  as downloaded_tab:

--- a/scripts/civitai_manager_libs/ishortcut_action.py
+++ b/scripts/civitai_manager_libs/ishortcut_action.py
@@ -71,8 +71,8 @@ def on_ui(selected_model_id:gr.Textbox, refresh_sc_list:gr.Textbox(), recipe_inp
                 civitai_model_url_txt = gr.Textbox(label="Model Url", value="", interactive=False , lines=1).style(container=True, show_copy_button=True)                   
                 with gr.Row():            
                     with gr.Column():
-                        with gr.Accordion("Classcification", open=True):
-                            model_classification = gr.Dropdown(label='Classcification', show_label=False ,multiselect=True, interactive=True, choices=classification.get_list())
+                        with gr.Accordion("Classification", open=True):
+                            model_classification = gr.Dropdown(label='Classification', show_label=False ,multiselect=True, interactive=True, choices=classification.get_list())
                             model_classification_update_btn = gr.Button(value="Update",variant="primary")
 
                         with gr.Accordion("Downloaded Version", open=True, visible=False) as downloaded_tab:                             


### PR DESCRIPTION
## The issue
Currently, there is a typo in the "Civitai Shortcut" tab of the extension. Specifically, the word "Classification" is spelled as "Classcification" in the information tab on the right side. 

## The solution
This PR replaces all instances of the typo within the project to the correct spelling.
I have also checked for the same typo case-insensitively and found no matches. I have tested the classification feature manually before & after my change and did not notice a difference in behavior.

## Demonstration
### Before
![before](https://github.com/sunnyark/civitai-shortcut/assets/80789459/49ac4713-2967-484c-8ddc-4790f5b42f5e)

### After
![after](https://github.com/sunnyark/civitai-shortcut/assets/80789459/c27b15cd-e741-4947-8d61-2491703e3dcf)
